### PR TITLE
Add half long rest behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## [1.1.0] 2020-08-03
+
+### ADDED
+
+- Configurable hit dice recovery multiplier.
+
+### CHANGED
+
+- Bump compatible core version.
+
 ## [1.0.0] 2020-06-17
 
 ### ADDED

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FVTT Long Rest Hit Dice Healing for D&D 5e
 
-Changes long rests in the dnd5e system to only allow healing via hit dice.
+Adds the "Slow Natural Healing" rules to the dnd5e system. Rather than healing to full hit points, actors now have the option to spend hit dice on a long rest.
 
 ## License
 

--- a/lr-hd-healing.js
+++ b/lr-hd-healing.js
@@ -2,107 +2,149 @@ import Actor5e from "../../systems/dnd5e/module/actor/entity.js";
 import HDLongRestDialog from "./new-long-rest.js";
 
 Hooks.on("init", () => {
-    Actor5e.prototype.longRest = async function({dialog=true, chat=true}={}) {
+    game.settings.register("long-rest-hd-healing", "recovery-mult", {
+        name: "Hit Dice Recovery Fraction",
+        hint: "The fraction of hit dice to recover on a long rest.",
+        scope: "world",
+        config: true,
+        type: String,
+        choices: {
+            quarter: "Quarter",
+            half: "Half (default)",
+            full: "Full",
+        },
+        default: "half",
+    });
+
+    patch_longRest();
+});
+
+function patch_longRest() {
+    Actor5e.prototype.longRest = async function ({ dialog = true, chat = true } = {}) {
         const data = this.data.data;
-    
+
         // Take note of the initial hit points and number of hit dice the Actor has
         const hd0 = data.attributes.hd;
         const hp0 = data.attributes.hp.value;
 
         // Maybe present a confirmation dialog
         let newDay = false;
-        if ( dialog ) {
-          try {
-            newDay = await HDLongRestDialog.hdLongRestDialog({actor: this, canRoll: hd0 > 0});
-          } catch(err) {
-            return;
-          }
+        if (dialog) {
+            try {
+                newDay = await HDLongRestDialog.hdLongRestDialog({ actor: this, canRoll: hd0 > 0 });
+            } catch (err) {
+                return;
+            }
         }
-    
+
         // Recover hit points to full, and eliminate any existing temporary HP
         const dhp = data.attributes.hp.value - hp0;
         const updateData = {
-          "data.attributes.hp.temp": 0,
-          "data.attributes.hp.tempmax": 0
+            "data.attributes.hp.temp": 0,
+            "data.attributes.hp.tempmax": 0,
         };
-    
+
         // Recover character resources
-        for ( let [k, r] of Object.entries(data.resources) ) {
-          if ( r.max && (r.sr || r.lr) ) {
-            updateData[`data.resources.${k}.value`] = r.max;
-          }
+        for (let [k, r] of Object.entries(data.resources)) {
+            if (r.max && (r.sr || r.lr)) {
+                updateData[`data.resources.${k}.value`] = r.max;
+            }
         }
-    
+
         // Recover spell slots
-        for ( let [k, v] of Object.entries(data.spells) ) {
-          if ( !v.max && !v.override ) continue;
-          updateData[`data.spells.${k}.value`] = v.override || v.max;
+        for (let [k, v] of Object.entries(data.spells)) {
+            if (!v.max && !v.override) continue;
+            updateData[`data.spells.${k}.value`] = v.override || v.max;
         }
-    
+
         // Recover pact slots.
         const pact = data.spells.pact;
-        updateData['data.spells.pact.value'] = pact.override || pact.max;
-    
+        updateData["data.spells.pact.value"] = pact.override || pact.max;
+
         // Determine the number of hit dice which may be recovered
-        let recoverHD = Math.max(Math.floor(data.details.level / 2), 1);
+        const recoveryMultSetting = game.settings.get("long-rest-hd-healing", "recovery-mult");
+        let recoveryMultiplier = 0.5;
+        switch (recoveryMultSetting) {
+            case "quarter":
+                recoveryMultiplier = 0.25;
+                break;
+            case "half":
+                recoveryMultiplier = 0.5;
+                break;
+            case "full":
+                recoveryMultiplier = 1.0;
+                break;
+            default:
+                throw new Error(`Unable to parse recovery multiplier setting, got "${recoveryMultSetting}".`);
+        }
+
+        let recoverHD = Math.max(Math.floor(data.details.level * recoveryMultiplier), 1);
         let dhd = 0;
-    
+
         // Sort classes which can recover HD, assuming players prefer recovering larger HD first.
-        const updateItems = this.items.filter(item => item.data.type === "class").sort((a, b) => {
-          let da = parseInt(a.data.data.hitDice.slice(1)) || 0;
-          let db = parseInt(b.data.data.hitDice.slice(1)) || 0;
-          return db - da;
-        }).reduce((updates, item) => {
-          const d = item.data.data;
-          if ( (recoverHD > 0) && (d.hitDiceUsed > 0) ) {
-            let delta = Math.min(d.hitDiceUsed || 0, recoverHD);
-            recoverHD -= delta;
-            dhd += delta;
-            updates.push({_id: item.id, "data.hitDiceUsed": d.hitDiceUsed - delta});
-          }
-          return updates;
-        }, []);
-    
+        const updateItems = this.items
+            .filter((item) => item.data.type === "class")
+            .sort((a, b) => {
+                let da = parseInt(a.data.data.hitDice.slice(1)) || 0;
+                let db = parseInt(b.data.data.hitDice.slice(1)) || 0;
+                return db - da;
+            })
+            .reduce((updates, item) => {
+                const d = item.data.data;
+                if (recoverHD > 0 && d.hitDiceUsed > 0) {
+                    let delta = Math.min(d.hitDiceUsed || 0, recoverHD);
+                    recoverHD -= delta;
+                    dhd += delta;
+                    updates.push({ _id: item.id, "data.hitDiceUsed": d.hitDiceUsed - delta });
+                }
+                return updates;
+            }, []);
+
         // Iterate over owned items, restoring uses per day and recovering Hit Dice
         const recovery = newDay ? ["sr", "lr", "day"] : ["sr", "lr"];
-        for ( let item of this.items ) {
-          const d = item.data.data;
-          if ( d.uses && recovery.includes(d.uses.per) ) {
-            updateItems.push({_id: item.id, "data.uses.value": d.uses.max});
-          }
-          else if ( d.recharge && d.recharge.value ) {
-            updateItems.push({_id: item.id, "data.recharge.charged": true});
-          }
+        for (let item of this.items) {
+            const d = item.data.data;
+            if (d.uses && recovery.includes(d.uses.per)) {
+                updateItems.push({ _id: item.id, "data.uses.value": d.uses.max });
+            } else if (d.recharge && d.recharge.value) {
+                updateItems.push({ _id: item.id, "data.recharge.charged": true });
+            }
         }
-    
+
         // Perform the updates
         await this.update(updateData);
-        if ( updateItems.length ) await this.updateEmbeddedEntity("OwnedItem", updateItems);
-    
+        if (updateItems.length) await this.updateEmbeddedEntity("OwnedItem", updateItems);
+
         // Display a Chat Message summarizing the rest effects
         let restFlavor;
         switch (game.settings.get("dnd5e", "restVariant")) {
-          case 'normal': restFlavor = game.i18n.localize(newDay ? "DND5E.LongRestOvernight" : "DND5E.LongRestNormal"); break;
-          case 'gritty': restFlavor = game.i18n.localize("DND5E.LongRestGritty"); break;
-          case 'epic':  restFlavor = game.i18n.localize("DND5E.LongRestEpic"); break;
+            case "normal":
+                restFlavor = game.i18n.localize(newDay ? "DND5E.LongRestOvernight" : "DND5E.LongRestNormal");
+                break;
+            case "gritty":
+                restFlavor = game.i18n.localize("DND5E.LongRestGritty");
+                break;
+            case "epic":
+                restFlavor = game.i18n.localize("DND5E.LongRestEpic");
+                break;
         }
-    
-        if ( chat ) {
-          ChatMessage.create({
-            user: game.user._id,
-            speaker: {actor: this, alias: this.name},
-            flavor: restFlavor,
-            content: game.i18n.format("DND5E.LongRestResult", {name: this.name, health: dhp, dice: dhd})
-          });
+
+        if (chat) {
+            ChatMessage.create({
+                user: game.user._id,
+                speaker: { actor: this, alias: this.name },
+                flavor: restFlavor,
+                content: game.i18n.format("DND5E.LongRestResult", { name: this.name, health: dhp, dice: dhd }),
+            });
         }
-    
+
         // Return data summarizing the rest effects
         return {
-          dhd: dhd,
-          dhp: dhp,
-          updateData: updateData,
-          updateItems: updateItems,
-          newDay: newDay
-        }
-      }
-});
+            dhd: dhd,
+            dhp: dhp,
+            updateData: updateData,
+            updateItems: updateItems,
+            newDay: newDay,
+        };
+    };
+}

--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
     "lr-hd-healing.js"
   ],
   "minimumCoreVersion": "0.6.2",
-  "compatibleCoreVersion": "0.6.5",
+  "compatibleCoreVersion": "0.7.5",
   "url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
   "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
   "download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/1.1.0.zip",

--- a/module.json
+++ b/module.json
@@ -1,21 +1,21 @@
 {
   "name": "long-rest-hd-healing",
   "title": "Long Rest Hit Die Healing for D&D5e",
-  "description": "Changes long rests in the dnd5e system to only allow healing via hit dice",
-  "systems": ["dnd5e"],
-  "version": "1.0.0",
+  "description": "Adds the \"Slow Natural Healing\" rules to the dnd5e system. Rather than healing to full hit points, actors now have the option to spend hit dice on a long rest.",
+  "systems": [
+    "dnd5e"
+  ],
+  "version": "1.1.0",
   "author": "Cole Schultz (cole#9640)",
   "esmodules": [
     "lr-hd-healing.js"
   ],
   "minimumCoreVersion": "0.6.2",
-  "compatibleCoreVersion": "0.6.2",
-	"url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
-	"manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
-	"download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/1.0.0.zip",
-	"license": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/1.0.0/LICENSE",
-	"readme": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/1.0.0/README.md",
-	"changelog": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/1.0.0/CHANGELOG.md"
+  "compatibleCoreVersion": "0.6.5",
+  "url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
+  "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
+  "download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/1.1.0.zip",
+  "license": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/1.1.0/LICENSE",
+  "readme": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/1.1.0/README.md",
+  "changelog": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/blob/1.1.0/CHANGELOG.md"
 }
-
- 

--- a/new-long-rest.js
+++ b/new-long-rest.js
@@ -16,7 +16,6 @@ export default class HDLongRestDialog extends ShortRestDialog {
     return data;
   }
 
-
     static async hdLongRestDialog({actor}={}) {
         return new Promise((resolve, reject) => {
           const dlg = new this(actor, {

--- a/new-long-rest.js
+++ b/new-long-rest.js
@@ -17,7 +17,7 @@ export default class HDLongRestDialog extends ShortRestDialog {
                 label: "Rest",
                 callback: html => {
                   let newDay = false;
-                  if (game.settings.get("dnd5e", "restVariant") === "gritty")
+                  if (game.settings.get("dnd5e", "restVariant") !== "epic")
                     newDay = html.find('input[name="newDay"]')[0].checked;
                   resolve(newDay);
                 }

--- a/new-long-rest.js
+++ b/new-long-rest.js
@@ -3,9 +3,19 @@ import ShortRestDialog from "../../systems/dnd5e/module/apps/short-rest.js";
 export default class HDLongRestDialog extends ShortRestDialog {
     static get defaultOptions() {
         return mergeObject(super.defaultOptions, {
-            template: "modules/long-rest-hd-healing/templates/hd-long-rest.html"
+          template: "modules/long-rest-hd-healing/templates/hd-long-rest.html",
+          classes: ["dnd5e", "dialog"]
         });
     }
+
+  getData() {
+    const data = super.getData();
+    const variant = game.settings.get("dnd5e", "restVariant");
+    data.promptNewDay = variant !== "gritty";     // It's always a new day when resting 1 week
+    data.newDay = variant === "normal";           // It's probably a new day when resting normally (8 hours)
+    return data;
+  }
+
 
     static async hdLongRestDialog({actor}={}) {
         return new Promise((resolve, reject) => {
@@ -17,8 +27,10 @@ export default class HDLongRestDialog extends ShortRestDialog {
                 label: "Rest",
                 callback: html => {
                   let newDay = false;
-                  if (game.settings.get("dnd5e", "restVariant") !== "epic")
+                  if (game.settings.get("dnd5e", "restVariant") === "normal")
                     newDay = html.find('input[name="newDay"]')[0].checked;
+                  else if (game.settings.get("dnd5e", "restVariant") === "gritty")
+                    newDay = true;
                   resolve(newDay);
                 }
               },


### PR DESCRIPTION
- Add a new user setting to activate the half recovery of long rest
- Add the half long rest behavior but not affecting short rest or "per day"
- Change the "newDay" setting to be available with both "gritty" and "normal" rest variant since this is the default for 5e 0.98