### PR TITLE
Add option to change hit dice recovery rounding

### DIFF
--- a/lr-hd-healing.js
+++ b/lr-hd-healing.js
@@ -77,6 +77,19 @@ Hooks.on("init", () => {
         default: "full",
     });
 
+    game.settings.register("long-rest-hd-healing", "recovery-rounding", {
+        name: "Hit Dice Recovery Rounding",
+        hint: "How to round the number of hit dice recovered.",
+        scope: "world",
+        config: true,
+        type: String,
+        choices: {
+            down: "Round down (default)",
+            up: "Round up",
+        },
+        default: "down",
+    });
+
     patch_longRest();
 });
 
@@ -140,10 +153,13 @@ function patch_longRest() {
         const recoveryHDMultSetting = game.settings.get("long-rest-hd-healing", "recovery-mult");
         const recoveryHDMultiplier = determineLongRestMultiplier(recoveryHDMultSetting);
 
+        const recoveryHDRoundSetting = game.settings.get("long-rest-hd-healing", "recovery-rounding");
+        const recoveryHDRoundingFn = recoveryHDRoundSetting === "down" ? Math.floor : Math.ceil;
+
         const updateItems = [];
         let dhd = 0;
         if (recoveryHDMultiplier !== 0) {
-            let recoverHD = Math.max(Math.floor(data.details.level * recoveryHDMultiplier), 1);
+            let recoverHD = Math.max(recoveryHDRoundingFn(data.details.level * recoveryHDMultiplier), 1);
 
             // Sort classes which can recover HD, assuming players prefer recovering larger HD first.
             const classItems = this.items


### PR DESCRIPTION
This adds a new setting, `recovery-rounding`, that allows the user to configure how the recovery hit dice are rounded.

Originally I was going to make a fork of this repo and hard-code the number of recovered hit dice to round up. My group's been playing with this IRL because we think it's cleaner than making an edge case for when there's only one hit dice left to recover. I then realised that I may as well add it as a configuration, in case others feel the same.

I've never made a Foundry mod before and I don't know how to test them without making a version release. If you can point me in the right direction, I'll test the changes and get back to you.