### PR TITLE
Update to FoundryVTT 0.8.x, drops 0.6/0.7 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+### CHANGED
+- Compatibility with Foundry 0.8.6 (no longer compatibile with 0.7.x)
+
 ## [2.2.0] 2021-01-21
 
 ### ADDED

--- a/lr-hd-healing.js
+++ b/lr-hd-healing.js
@@ -219,7 +219,7 @@ function patch_longRest() {
 
         // Perform the updates
         await this.update(updateData);
-        if (updateItems.length) await this.updateEmbeddedEntity("OwnedItem", updateItems);
+        if (updateItems.length) await this.updateEmbeddedDocuments("Item", updateItems);
 
         // Display a Chat Message summarizing the rest effects
         let restFlavor;

--- a/module.json
+++ b/module.json
@@ -10,8 +10,8 @@
   "esmodules": [
     "lr-hd-healing.js"
   ],
-  "minimumCoreVersion": "0.6.2",
-  "compatibleCoreVersion": "0.7.9",
+  "minimumCoreVersion": "0.8.0",
+  "compatibleCoreVersion": "0.8.6",
   "url": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e",
   "manifest": "https://raw.githubusercontent.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/master/module.json",
   "download": "https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/archive/2.2.0.zip",


### PR DESCRIPTION
Support for 0.8.6
https://github.com/schultzcole/FVTT-Long-Rest-HD-Healing-5e/issues/10 

Disclaimers:
- I have no experience with Foundry API
- I did not verify that it works with 0.8. **0**
- I did not verify that it doesn't work with older Foundry VTT versions, but given that this was a breaking API change I would expect to not work.
..I did verify that the change did restore hit dice used on my test world server with F VTT 0.8.6 and Dnd5e 1.3.3 with no other modules active. Even if it is not full valid migration it can hopefully serve as a good starting point (and "appears to work" seems like a step up from current "doesn't work on 0.8 for sure" state). 

